### PR TITLE
[FIX] Don't allow to modify price_unit of a pack_line if its parent p…

### DIFF
--- a/sale_product_pack/models/sale_order_line.py
+++ b/sale_product_pack/models/sale_order_line.py
@@ -52,6 +52,10 @@ class SaleOrderLine(models.Model):
                         self.create(vals)
                 else:
                     self.create(vals)
+        else:
+            if not self.product_id.pack_ok and self.pack_parent_line_id and self.pack_parent_line_id.pack_type == \
+                "detailed" and self.pack_parent_line_id.product_id.pack_component_price in {"totalized", "ignored"}:
+                self.write({"price_unit": 0.0})
 
     @api.model
     def create(self, vals):


### PR DESCRIPTION
…ack_component_price is 'totalized' or 'ignored'.

Basically, this is a fix to solve the problem that happens when you try to register the payment on the website after completing the address information.